### PR TITLE
设置为单例模式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/vnpy_mysql/mysql_database.py
+++ b/vnpy_mysql/mysql_database.py
@@ -131,6 +131,12 @@ class DbBarOverview(Model):
 class MysqlDatabase(BaseDatabase):
     """Mysql数据库接口"""
 
+    def __new__(cls, *args, **kwargs):
+        """保持单例模式，由于db是单例"""
+        if not hasattr(cls, '_instance'):
+            cls._instance = super().__new__(cls, *args, **kwargs)
+        return cls._instance
+
     def __init__(self) -> None:
         """"""
         self.db = db


### PR DESCRIPTION
由于db: PeeweeMySQLDatabase是模块级变量，符合单例模式，MysqlDatabase应保持单例。
虽然MysqlDatabase实例一般情况下由vnpy.trader.database.get_database函数进行实例化维持单例，但该类在单独实例化或者及其子类实例化时（扩展需要），该类及其子类将执行多次数据库连接，抛出异常OperationalError('Connection already opened.')。
另外vnpy.trader.database.get_database维持数据库对象的单例，常常也会遇到困难，特别是需要修改get_database内部逻辑时，比如从自己项目中加载模块时。

注意：如果无法避免MysqlDatabase和其子类将同时使用，请确保子类先被实例化，否则全局会存在一个父类实例。由于这个原因强烈建议get_database不要在任何需要获得数据库对象的类的构造函数中执行，避免get_database的调用无法被重写。可能造成MysqlDatabase率先实例化而不是其子类。

典型例子如下：
```
class RecorderEngine(BaseEngine):
    """
    For running data recorder.
    """
    def __init__(self, main_engine: MainEngine, event_engine: EventEngine) -> None:
        """"""
        super().__init__(main_engine, event_engine, APP_NAME)
        # ......
        self.database: BaseDatabase = get_database()

```
```
class MyRecorderEngine(RecorderEngine):
    def __init__(self, main_engine: MainEngine, event_engine: EventEngine):
        super().__init__(main_engine, event_engine)  # 父类依然会执行get_database()
        self.database: BaseDatabase = get_my_database()  # 执行自定义逻辑
```