### PR TITLE
让dbtickdata表datetime列默认精确度支持毫秒

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,6 @@ VeighNa不会主动为MySQL数据库创建实例，所以使用前请确保datab
 
 若实例尚未创建，可以使用【MySQL Workbench】客户端的【new_schema】进行操作。
 
-### Tick时间戳的毫秒支持
-
-由于peewee的建表功能限制，默认情况下在保存tick数据时，时间精确度只能精确到秒。如果影响使用，可按照以下方式手动修改MySQL数据表来解决：
-
-```
-# 用MySQL命令行工具连接数据库
-
-# 选择数据实例
-use vnpy;
-
-# 修改dbtickdata表datetime列的数据格式
-ALTER TABLE `dbtickdata` MODIFY COLUMN `datetime` DATETIME(3);
-```
 
 ### 字符串大小写敏感支持
 

--- a/vnpy_mysql/mysql_database.py
+++ b/vnpy_mysql/mysql_database.py
@@ -34,6 +34,12 @@ db = PeeweeMySQLDatabase(
 )
 
 
+class DateTimeMillisecondField(DateTimeField):
+    # 毫秒支持
+    def get_modifiers(self):
+        return [3]
+
+
 class DbBarData(Model):
     """K线数据表映射对象"""
 
@@ -64,7 +70,7 @@ class DbTickData(Model):
 
     symbol: str = CharField()
     exchange: str = CharField()
-    datetime: datetime = DateTimeField()
+    datetime: datetime = DateTimeMillisecondField()
 
     name: str = CharField()
     volume: float = FloatField()


### PR DESCRIPTION
通过自定义时间类型，让peewee在自动建表时，就已支持毫秒